### PR TITLE
Recalled items should display as such in MyAccount

### DIFF
--- a/module/UChicago/config/module.config.php
+++ b/module/UChicago/config/module.config.php
@@ -3,9 +3,12 @@ return [
     'controllers' => [
       'factories' => [
         'VuFindAdmin\Controller\PinController' => 'VuFind\Controller\AbstractBaseFactory',
+        'UChicago\Controller\MyResearchController' => 'VuFind\Controller\AbstractBaseFactory',
       ],
       'aliases' => [
         'Pin' => 'VuFindAdmin\Controller\PinController',
+        'MyResearch' => 'UChicago\Controller\MyResearchController',
+        'myresearch' => 'UChicago\Controller\MyResearchController',
       ],
     ],
     'router' => [

--- a/module/UChicago/src/UChicago/Controller/MyResearchController.php
+++ b/module/UChicago/src/UChicago/Controller/MyResearchController.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * MyResearch Controller
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace UChicago\Controller;
+
+use Laminas\Stdlib\Parameters;
+use Laminas\View\Model\ViewModel;
+use VuFind\Exception\Auth as AuthException;
+use VuFind\Exception\AuthEmailNotVerified as AuthEmailNotVerifiedException;
+use VuFind\Exception\AuthInProgress as AuthInProgressException;
+use VuFind\Exception\Forbidden as ForbiddenException;
+use VuFind\Exception\ILS as ILSException;
+use VuFind\Exception\ListPermission as ListPermissionException;
+use VuFind\Exception\Mail as MailException;
+use VuFind\ILS\PaginationHelper;
+use VuFind\Search\RecommendListener;
+
+/**
+ * Controller for the user account area.
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class MyResearchController extends \VuFind\Controller\MyResearchController
+{
+
+    /**
+     * Send list of checked out books to view
+     *
+     * @return mixed
+     */
+    public function checkedoutAction()
+    {
+        // Stop now if the user does not have valid catalog credentials available:
+        if (!is_array($patron = $this->catalogLogin())) {
+            return $patron;
+        }
+
+        // Connect to the ILS:
+        $catalog = $this->getILS();
+
+        // Display account blocks, if any:
+        $this->addAccountBlocksToFlashMessenger($catalog, $patron);
+
+        // Get the current renewal status and process renewal form, if necessary:
+        $renewStatus = $catalog->checkFunction('Renewals', compact('patron'));
+        $renewResult = $renewStatus
+            ? $this->renewals()->processRenewals(
+                $this->getRequest()->getPost(),
+                $catalog,
+                $patron,
+                $this->serviceLocator->get(\VuFind\Validator\Csrf::class)
+            )
+            : [];
+
+        // By default, assume we will not need to display a renewal form:
+        $renewForm = false;
+
+        // Get paging setup:
+        $config = $this->getConfig();
+        $pageOptions = $this->getPaginationHelper()->getOptions(
+            (int)$this->params()->fromQuery('page', 1),
+            $this->params()->fromQuery('sort'),
+            $config->Catalog->checked_out_page_size ?? 50,
+            $catalog->checkFunction('getMyTransactions', $patron)
+        );
+
+        // Get checked out item details:
+        $result = $catalog->getMyTransactions($patron, $pageOptions['ilsParams']);
+
+        // Build paginator if needed:
+        $paginator = $this->getPaginationHelper()->getPaginator(
+            $pageOptions, $result['count'], $result['records']
+        );
+        if ($paginator) {
+            $pageStart = $paginator->getAbsoluteItemNumber(1) - 1;
+            $pageEnd = $paginator->getAbsoluteItemNumber($pageOptions['limit']) - 1;
+        } else {
+            $pageStart = 0;
+            $pageEnd = $result['count'];
+        }
+
+        // If the results are not paged in the ILS, collect up to date stats for ajax
+        // account notifications:
+        if ((!$pageOptions['ilsPaging'] || !$paginator)
+            && !empty($this->getConfig()->Authentication->enableAjax)
+        ) {
+            $accountStatus = [
+                'ok' => 0,
+                'warn' => 0,
+                'overdue' => 0
+            ];
+        } else {
+            $accountStatus = null;
+        }
+
+        $driversNeeded = $hiddenTransactions = [];
+        foreach ($result['records'] as $i => $current) {
+            // Add renewal details if appropriate:
+            $current = $this->renewals()->addRenewDetails(
+                $catalog, $current, $renewStatus
+            );
+            if ($renewStatus && !isset($current['renew_link'])
+                && $current['renewable']
+            ) {
+                // Enable renewal form if necessary:
+                $renewForm = true;
+            }
+
+            if (null !== $accountStatus) {
+                switch ($current['dueStatus'] ?? '') {
+                case 'due':
+                    $accountStatus['warn']++;
+                    break;
+                case 'overdue':
+                    $accountStatus['overdue']++;
+                    break;
+                default:
+                    $accountStatus['ok']++;
+                    break;
+                }
+            }
+
+            // Build record drivers (only for the current visible page):
+            if ($pageOptions['ilsPaging'] || ($i >= $pageStart && $i <= $pageEnd)) {
+                $driversNeeded[] = $current;
+            } else {
+                $hiddenTransactions[] = $current;
+            }
+        }
+
+        $transactions = $this->ilsRecords()->getDrivers($driversNeeded);
+        $hasRecalls = $this->hasRecallsUC($transactions);
+
+        $displayItemBarcode
+            = !empty($config->Catalog->display_checked_out_item_barcode);
+
+        $ilsPaging = $pageOptions['ilsPaging'];
+        $sortList = $pageOptions['sortList'];
+        $params = $pageOptions['ilsParams'];
+        return $this->createViewModel(
+            compact(
+                'transactions', 'renewForm', 'renewResult', 'paginator', 'ilsPaging',
+                'hiddenTransactions', 'displayItemBarcode', 'sortList', 'params',
+                'accountStatus', 'hasRecalls'
+            )
+        );
+    }
+
+    /**
+     * Determines if any transactions have a recall associated with them.
+     *
+     * @param $transactions array
+     *
+     * @return bool
+     */
+    protected function hasRecallsUC($transactions)
+    {
+        foreach ($transactions as $resource) {
+            $ilsDetails = $resource->getExtraDetail('ils_details');
+            if ($ilsDetails['recalled'] == true) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/module/UChicago/src/UChicago/ILS/Driver/Folio.php
+++ b/module/UChicago/src/UChicago/ILS/Driver/Folio.php
@@ -356,6 +356,74 @@ class Folio extends \VuFind\ILS\Driver\Folio
     }
 
     /**
+     * This method queries the ILS for a patron's current checked out items
+     *
+     * Input: Patron array returned by patronLogin method
+     * Output: Returns an array of associative arrays.
+     *         Each associative array contains these keys:
+     *         duedate - The item's due date (a string).
+     *         dueTime - The item's due time (a string, optional).
+     *         dueStatus - A special status – may be 'due' (for items due very soon)
+     *                     or 'overdue' (for overdue items). (optional).
+     *         id - The bibliographic ID of the checked out item.
+     *         source - The search backend from which the record may be retrieved
+     *                  (optional - defaults to Solr). Introduced in VuFind 2.4.
+     *         barcode - The barcode of the item (optional).
+     *         renew - The number of times the item has been renewed (optional).
+     *         renewLimit - The maximum number of renewals allowed
+     *                      (optional - introduced in VuFind 2.3).
+     *         request - The number of pending requests for the item (optional).
+     *         volume – The volume number of the item (optional).
+     *         publication_year – The publication year of the item (optional).
+     *         renewable – Whether or not an item is renewable
+     *                     (required for renewals).
+     *         message – A message regarding the item (optional).
+     *         title - The title of the item (optional – only used if the record
+     *                                        cannot be found in VuFind's index).
+     *         item_id - this is used to match up renew responses and must match
+     *                   the item_id in the renew response.
+     *         institution_name - Display name of the institution that owns the item.
+     *         isbn - An ISBN for use in cover image loading
+     *                (optional – introduced in release 2.3)
+     *         issn - An ISSN for use in cover image loading
+     *                (optional – introduced in release 2.3)
+     *         oclc - An OCLC number for use in cover image loading
+     *                (optional – introduced in release 2.3)
+     *         upc - A UPC for use in cover image loading
+     *               (optional – introduced in release 2.3)
+     *         borrowingLocation - A string describing the location where the item
+     *                         was checked out (optional – introduced in release 2.4)
+     *
+     * @param array $patron Patron login information from $this->patronLogin
+     *
+     * @return array Transactions associative arrays
+     */
+    public function getMyTransactions($patron)
+    {
+        $query = ['query' => 'userId==' . $patron['id'] . ' and status.name==Open'];
+        $transactions = [];
+        foreach ($this->getPagedResults(
+            'loans', '/circulation/loans', $query
+        ) as $trans) {
+            $date = date_create($trans->dueDate);
+            $transactions[] = [
+                'duedate' => date_format($date, "j M Y"),
+                'dueTime' => date_format($date, "g:i:s a"),
+                // TODO: Due Status
+                // 'dueStatus' => $trans['itemId'],
+                'id' => $this->getBibId($trans->item->instanceId),
+                'item_id' => $trans->item->id,
+                'barcode' => $trans->item->barcode,
+                'renew' => $trans->renewalCount ?? 0,
+                'renewable' => true,
+                'title' => $trans->item->title,
+                'recalled' => $trans->action == 'recallrequested',
+            ];
+        }
+        return $transactions;
+    }
+
+    /**
      * This is a copy of VuFind/ILS/Driver/AbstractAPI.php with the case statement
      * taken out. We do not want to throw a RecordMissing for an entire record when
      * one of the auxiliary data APIs returns a 404.

--- a/themes/phoenix/templates/myresearch/checkedout.phtml
+++ b/themes/phoenix/templates/myresearch/checkedout.phtml
@@ -14,20 +14,21 @@ $renewAll = !$this->ilsPaging || !$paginator;
 </a>
 
 <div class="<?=$this->layoutClass('mainbody')?>">
-    <div class="alert alert-warning" role="alert">
-	<p>
-	    We are currently working to restore the ability to sort checked out items and the display of some data fields.
-	</p>
+  <? ### UChicago customization ### ?>
+  <?php if ($this->hasRecalls):?>
+    <div class="alert alert-danger" role="alert">
+      <p>You have item(s) recalled.</P>
     </div>
-    <div class="alert alert-warning" role="alert">
-	<p>
-	    <b>
-		Interlibrary Loan items, reserves items, short term loan items, and recalled items are ineligible for renewal.
-	    </b>
-	    <p>
-		Standard loans are not yet eligible for renewal; we are exploring whether we can provide automated renewals for eligible materials.
-	    </p>
-    </div>
+  <?php endif; ?>
+
+  <div class="alert alert-warning" role="alert">
+    <p>We are currently working to restore the ability to sort checked out items and the display of some data fields.</p>
+  </div>
+  <div class="alert alert-warning" role="alert">
+    <p><strong>Interlibrary Loan items, reserves items, short term loan items, and recalled items are ineligible for renewal.</strong></p>
+    <p>Standard loans are not yet eligible for renewal; we are exploring whether we can provide automated renewals for eligible materials.</p>
+  </div>
+  <? ### ./UChicago customization ### ?>
   <h2><?=$this->transEsc('Your Checked Out Items')?></h2>
   <?=$this->flashmessages()?>
 
@@ -172,6 +173,13 @@ $renewAll = !$this->ilsPaging || !$paginator;
                 <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEscWithPrefix('location_', $ilsDetails['borrowingLocation'])?>
                 <br />
               <?php endif; ?>
+
+              <? ### UChicago customization ### ?>
+              <?php if (isset($ilsDetails['recalled']) && $ilsDetails['recalled'] === true): ?>
+                <strong class="text-danger"><?=$this->transEsc('This item has been recalled')?></strong>
+                <br />
+              <?php endif; ?>
+              <? ### ./UChicago customization ### ?>
 
               <?php if (isset($ilsDetails['renew'])): ?>
                 <strong><?=$this->transEsc('Renewed')?>:</strong> <?=$this->transEsc($ilsDetails['renew'])?>


### PR DESCRIPTION
Fixes #117 

## Adds
- A banner at the top of the checked out items page if any items have been recalled.
- Alert text on any item that has been recalled.

## Note
Most of the code in `MyResearchController.php` is just a copy of the function we're overriding, so you don't need to read it too carefully, however, you could diff it with the VuFind module version if you wanted to see how it differs.