### PR TITLE
Correct formatting in email records

### DIFF
--- a/module/UChicago/config/module.config.php
+++ b/module/UChicago/config/module.config.php
@@ -36,16 +36,15 @@ return [
       ],
     ],
     'service_manager' =>
-    array (
+    [
         'allow_override' => true,
-        'factories' =>
-        array (
+        'factories' => [
             'UChicago\Mailer\Mailer' => 'VuFind\Mailer\Factory',
-        ),           
+        ],           
         'aliases' => [
             'UChicago\Mailer' => 'UChicago\Mailer\Mailer',
         ],
-    ),
+    ],
     'vufind' => [
         'plugin_managers' => [
             'ils_driver' => [

--- a/module/UChicago/config/module.config.php
+++ b/module/UChicago/config/module.config.php
@@ -3,6 +3,7 @@ return [
     'controllers' => [
       'factories' => [
         'VuFindAdmin\Controller\PinController' => 'VuFind\Controller\AbstractBaseFactory',
+        'UChicago\Controller\CartController' => 'VuFind\Controller\CartControllerFactory',
         'UChicago\Controller\MyResearchController' => 'VuFind\Controller\AbstractBaseFactory',
         'UChicago\Controller\HoldsController' => 'VuFind\Controller\HoldsControllerFactory',
       ],
@@ -12,6 +13,8 @@ return [
         'myresearch' => 'UChicago\Controller\MyResearchController',
         'Holds' => 'UChicago\Controller\HoldsController',
         'holds' => 'UChicago\Controller\HoldsController',
+        'Cart' => 'UChicago\Controller\CartController',
+        'cart' => 'UChicago\Controller\CartController',
       ],
     ],
     'router' => [
@@ -32,6 +35,17 @@ return [
         ],
       ],
     ],
+    'service_manager' =>
+    array (
+        'allow_override' => true,
+        'factories' =>
+        array (
+            'UChicago\Mailer\Mailer' => 'VuFind\Mailer\Factory',
+        ),           
+        'aliases' => [
+            'UChicago\Mailer' => 'UChicago\Mailer\Mailer',
+        ],
+    ),
     'vufind' => [
         'plugin_managers' => [
             'ils_driver' => [

--- a/module/UChicago/src/UChicago/Controller/CartController.php
+++ b/module/UChicago/src/UChicago/Controller/CartController.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Book Bag / Bulk Action Controller
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace UChicago\Controller;
+
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\Session\Container;
+use VuFind\Exception\Forbidden as ForbiddenException;
+use VuFind\Exception\Mail as MailException;
+
+/**
+ * Book Bag / Bulk Action Controller
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class CartController extends \VuFind\Controller\CartController
+{
+    /**
+     * Email a batch of records.
+     *
+     * @return mixed
+     */
+    public function emailAction()
+    {
+        // Retrieve ID list:
+        $ids = null === $this->params()->fromPost('selectAll')
+            ? $this->params()->fromPost('ids')
+            : $this->params()->fromPost('idsAll');
+
+        // Retrieve follow-up information if necessary:
+        if (!is_array($ids) || empty($ids)) {
+            $ids = $this->followup()->retrieveAndClear('cartIds');
+        }
+        if (!is_array($ids) || empty($ids)) {
+            return $this->redirectToSource('error', 'bulk_noitems_advice');
+        }
+
+        // Force login if necessary:
+        $config = $this->getConfig();
+        if ((!isset($config->Mail->require_login) || $config->Mail->require_login)
+            && !$this->getUser()
+        ) {
+            return $this->forceLogin(
+                null, ['cartIds' => $ids, 'cartAction' => 'Email']
+            );
+        }
+
+        $view = $this->createEmailViewModel(
+            null, $this->translate('bulk_email_title')
+        );
+        $view->records = $this->getRecordLoader()->loadBatch($ids);
+        // Set up Captcha
+        $view->useCaptcha = $this->captcha()->active('email');
+
+        // Process form submission:
+        if ($this->formWasSubmitted('submit', $view->useCaptcha)) {
+            // Build the URL to share:
+            $params = [];
+            foreach ($ids as $current) {
+                $params[] = urlencode('id[]') . '=' . urlencode($current);
+            }
+            $url = $this->getServerUrl('records-home') . '?' . implode('&', $params);
+
+            // Attempt to send the email and show an appropriate flash message:
+            try {
+                // If we got this far, we're ready to send the email:
+                $mailer = $this->serviceLocator->get(\UChicago\Mailer\Mailer::class);
+                $mailer->setMaxRecipients($view->maxRecipients);
+                $cc = $this->params()->fromPost('ccself') && $view->from != $view->to
+                    ? $view->from : null;
+                $mailer->sendRecords(
+                    $view->to, $view->from, $view->message . 'THIS IS A TEST. TEST TEST TEST TEST TEST TEST TEST TEST TEST',
+                    $view->records, $this->getViewRenderer(), $view->subject, $cc
+                );
+                return $this->redirectToSource('success', 'bulk_email_success');
+            } catch (MailException $e) {
+                $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+            }
+        }
+
+        return $view;
+    }
+}

--- a/module/UChicago/src/UChicago/Mailer/Mailer.php
+++ b/module/UChicago/src/UChicago/Mailer/Mailer.php
@@ -53,7 +53,6 @@ class Mailer extends \VuFind\Mailer\Mailer
         }
 
         $body = '';
-              // 'FOOBAR FOOOOO FOOBAR FOOOOOOO FOOBAR. ' . $msg;
         for ($r = 0; $r < count($records); $r++) {
             if ($r == count($records) - 1) {
                 $m = $msg;

--- a/module/UChicago/src/UChicago/Mailer/Mailer.php
+++ b/module/UChicago/src/UChicago/Mailer/Mailer.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * VuFind Mailer Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2009.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Mailer
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace UChicago\Mailer;
+
+use Laminas\Mail\Header\ContentType;
+use Laminas\Mail\Message;
+use Laminas\Mime\Message as MimeMessage;
+use Laminas\Mime\Mime;
+use Laminas\Mime\Part as MimePart;
+use VuFind\Exception\Mail as MailException;
+
+/**
+ * VuFind Mailer Class
+ *
+ * @category VuFind
+ * @package  Mailer
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class Mailer extends \VuFind\Mailer\Mailer
+{
+    public function sendRecords($to, $from, $msg, $records, $view, $subject = null,
+                                $cc = null)
+    {
+        if (null === $subject) {
+            $subject = $this->translate('Library Catalog Records');
+        }
+
+        $body = '';
+              // 'FOOBAR FOOOOO FOOBAR FOOOOOOO FOOBAR. ' . $msg;
+        for ($r = 0; $r < count($records); $r++) {
+            if ($r == count($records) - 1) {
+                $m = $msg;
+            } else {
+                $m = '';
+            }
+            $body .= $view->partial(
+                'Email/record.phtml',
+                ['driver' => $records[$r], 'to' => $to, 'from' => $from, 'message' => $m]
+            );
+        }
+        return $this->send($to, $from, $subject, $body, $cc);
+    }
+
+}

--- a/themes/phoenix/templates/Email/record.phtml
+++ b/themes/phoenix/templates/Email/record.phtml
@@ -14,8 +14,6 @@ foreach ($holdings['holdings'] as $location => $holding) {
         $item = $holding['items'][0];
         echo $item['callnumber'] . "\n";
         echo $item['location'] . "\n\n";
-    } else {
-        ;
     }
 }
 ?>

--- a/themes/phoenix/templates/Email/record.phtml
+++ b/themes/phoenix/templates/Email/record.phtml
@@ -1,0 +1,23 @@
+<?php // This is a text-only email template; do not include HTML!
+$pubDetails = $this->driver->tryMethod('getPublicationDetails');
+$edition = $this->driver->tryMethod('getEdition');
+if (is_array($edition)) {
+    $edition = implode(" ", $edition);
+}
+$imprint = implode("\n", $pubDetails) . $edition;
+$holdings = $this->driver->getRealTimeHoldings();
+?>
+<?=$this->driver->getTitle() . ' ' . $this->driver->getTitleStatement() . ' ' . $imprint . "\n\n"?>
+<?php
+foreach ($holdings['holdings'] as $location => $holding) {
+    if (!empty($holding['items'][0]['location'])) {
+        $item = $holding['items'][0];
+        echo $item['callnumber'] . "\n";
+        echo $item['location'] . "\n\n";
+    } else {
+        ;
+    }
+}
+?>
+<?=$this->serverUrl($this->recordLink()->getUrl($this->driver))?>
+<?php echo "\n\n"; ?>

--- a/themes/phoenix/templates/Email/record.phtml
+++ b/themes/phoenix/templates/Email/record.phtml
@@ -18,4 +18,4 @@ foreach ($holdings['holdings'] as $location => $holding) {
 }
 ?>
 <?=$this->serverUrl($this->recordLink()->getUrl($this->driver))?>
-<?php echo "\n\n"; ?>
+<?="\n\n"?>


### PR DESCRIPTION
Fixes #126.

This involved overriding `CartController.php` and `Mailer.php`, so that `sendRecord` could use a new template, enriched with more information about the record, and that `emailAction` in `CartController` could use a new function called `sendRecords` rather than stock VuFind's `sendLink` to email a list of records from a search results page.