### PR TITLE
Timeout on login for user accounts with lots of checked out items

### DIFF
--- a/local/config/vufind/config_base.ini
+++ b/local/config/vufind/config_base.ini
@@ -373,7 +373,7 @@ holdings_text_fields[] = 'indexes'
 
 ; The number of checked out items to display per page; 0 for no limit (may cause
 ; memory problems for users with huge numbers of items). Default = 50.
-;checked_out_page_size = 50
+checked_out_page_size = 30
 
 ; The number of historic loans to display per page; 0 for no limit (may cause
 ; memory problems for users with a large number of historic loans). Default = 50


### PR DESCRIPTION
Fixes #128.

VuFind times out on login for users with hundreds of items checked out. It can also be unbearably slow for users with fewer items than that. This turns out to be caused by a confluence of issues. Our enhancements made the problem worse but there are also issues with stock VuFind where the bulk of this problem occurs. The VuFind/Folio driver `getBibId` method seems to be a particular trouble spot (probably due to its reliance on `getInstanceById`) and might need to be addressed in a future pull request.  

## Changes in this pull request
- Better leveraging of generators.
- More thorough caching.
- Show fewer items by default when users log in.
- Modification of code to only return bib number and item information for the items that are currently displayed on the screen at any given time.