### PR TITLE
Sort options for checked out items in my account

### DIFF
--- a/module/UChicago/src/UChicago/Controller/MyResearchController.php
+++ b/module/UChicago/src/UChicago/Controller/MyResearchController.php
@@ -116,6 +116,21 @@ class MyResearchController extends \VuFind\Controller\MyResearchController
             $config->Catalog->checked_out_page_size ?? 50,
             $catalog->checkFunction('getMyTransactions', $patron)
         );
+        $currSort = $this->params()->fromQuery('sort');
+        $pageOptions['ilsParams']['sort'] = $currSort;
+        $sortOptions = [
+            'dueDate' => 'Due Date',
+            'title' => 'Title',
+            'author' => 'Author',
+        ];
+        $pageOptions['sortList'] = [];
+        foreach ($sortOptions as $sortName => $sortDisplayText) {
+            $pageOptions['sortList'][$sortName] = [
+                'desc' => $sortDisplayText,
+                'url' => '?sort=' . $sortName,
+                'selected' => ($sortName == $currSort)
+            ];
+        }
 
         // Get checked out item details:
         $result = $catalog->getMyTransactions($patron, $pageOptions['ilsParams']);

--- a/module/UChicago/src/UChicago/ILS/Driver/Folio.php
+++ b/module/UChicago/src/UChicago/ILS/Driver/Folio.php
@@ -4,6 +4,7 @@ namespace UChicago\ILS\Driver;
 
 class Folio extends \VuFind\ILS\Driver\Folio
 {
+
     /**
      * Helper function to retrieve paged results from FOLIO API
      *
@@ -406,54 +407,16 @@ class Folio extends \VuFind\ILS\Driver\Folio
         }
         $query = ['query' => 'userId==' . $patron['id'] . ' and status.name==Open'];
         $transactions = [];
-        $i = 0;
         $bib = null; // null bib for items we're not currently showing on the page.
         foreach ($this->getPagedResults(
             'loans', '/circulation/loans', $query
         ) as $trans) {
-            $callnumber = '';
-            $locationData = '';
-            $itemId = $trans->item->id ?? '';
-            $query = ['query' => 'id==' . $itemId];
-            // Only get item information and bib number, etc. for items that we're planning
-            // to show on the screen at any given time.
-            $pageSize = $this->config['MyAccount']['checked_out_page_size'] ?? 50;
-            $maxPage = $pageSize * $pnum;
-            $minPage = $maxPage - $pageSize;
-            if ($i >= $minPage && $i <= $maxPage) {
-                // There is always only 1 item in this loop which is why we can set the return value
-                // outside of it. We only use this because the generator executes faster.
-                foreach ($this->getPagedResults(
-                    'items', '/item-storage/items', $query
-                ) as $item) {
-                    if (!empty($item->effectiveCallNumberComponents->callNumber)) {
-                        $callnumber = $item->effectiveCallNumberComponents->callNumber;
-                    }
-                    if (!empty($item->copyNumber)) {
-                        $callnumber .= ' ' . $item->copyNumber;
-                    }
-                    $effectiveLocationId = $item->effectiveLocationId;
-                    $locationData = $this->getLocationData($effectiveLocationId);
 
-                    $loanPolicyId = $trans->loanPolicyId ?? '';
-                    $loanPolicyData = '';
-                    if (!empty($loanPolicyId)) {
-                        $loanPolicyData = $this->getLoanPolicyData($loanPolicyId);
-                    }
+            $authors = implode(', ', array_map(function($c) {
+                return $c->name;
+            }, $trans->item->contributors ?? []));
 
-                    // Cache bib numbers by item id to improve login speed for users
-                    // who login a second time. For some reason getBibId is very slow.
-                    $cacheKey = 'loanBibMap';
-                    $loanBibMap = $this->getCachedData($cacheKey);
-                    if (!empty($loanBibMap[$trans->item->id])) {
-                        $bib = $loanBibMap[$trans->item->id]['bib'];
-                    } else {
-                        $bib = $this->getBibId($trans->item->instanceId);
-                        $loanBibMap[$trans->item->id] = compact('bib');
-                    }
-                    $this->putCachedData($cacheKey, $loanBibMap);
-                }
-            }
+            $loanDate = date_create($trans->loanDate);
             $date = date_create($trans->dueDate);
             $transactions[] = [
                 'duedate' => date_format($date, "j M Y"),
@@ -466,13 +429,86 @@ class Folio extends \VuFind\ILS\Driver\Folio
                 'renew' => $trans->renewalCount ?? 0,
                 'renewable' => true,
                 'title' => $trans->item->title,
-                'location' => $locationData['name'] ?? '',
-                'loan_policy' => $loanPolicyData['desc'] ?? '',
+                'location' => '',
+                'loan_policy_id' => $trans->loanPolicyId ?? '',
+                'loan_policy' => '',
                 'status' => $trans->item->status->name ?? '',
-                'callnumber' => $callnumber,
+                'callnumber' => '',
                 'recalled' => $trans->action == 'recallrequested',
+                'duedate_raw' => $date,
+                'loandate_raw' => $loanDate,
+                'item_instance_id' => $trans->item->instanceId,
+                'authors' => $authors,
             ];
-            $i++;
+        }
+
+        // Get the sort order
+        $sort = $this->getCoiSort();
+
+        // Sort before getting item informaion.
+        if (!empty($transactions)) {
+            switch($sort) {
+                case 'title':
+                    usort($transactions, $this->alphaStringComp('title'));
+                    break;
+                case 'author':
+                    usort($transactions, $this->alphaStringComp('authors'));
+                    break;
+                default:
+                    usort($transactions, $this->dateComp('duedate_raw'));
+                    break;
+            }
+        }
+
+        // Only get item information and bib number, etc. for items that we're planning
+        // to show on the screen at any given time.
+        $pageSize = $this->config['MyAccount']['checked_out_page_size'] ?? 50;
+        $maxPage = $pageSize * $pnum;
+        $minPage = $maxPage - $pageSize;
+        $slice = array_slice($transactions, $minPage, $pageSize, $preserve_keys=true);
+        foreach ($slice as $i => $trans) {
+            $callnumber = '';
+            $locationData = '';
+            $itemId = $trans['item_id'];
+            $query = ['query' => 'id==' . $itemId];
+            // There is always only 1 item in this loop which is why we can set the return value
+            // outside of it. We only use this because the generator executes faster.
+            foreach ($this->getPagedResults(
+                'items', '/item-storage/items', $query
+            ) as $item) {
+                if (!empty($item->effectiveCallNumberComponents->callNumber)) {
+                    $callnumber = $item->effectiveCallNumberComponents->callNumber;
+                }
+                if (!empty($item->copyNumber)) {
+                    $callnumber .= ' ' . $item->copyNumber;
+                }
+                $effectiveLocationId = $item->effectiveLocationId;
+                $locationData = $this->getLocationData($effectiveLocationId);
+
+                $loanPolicyId = $trans['loan_policy_id'];
+                $loanPolicyData = '';
+                if (!empty($loanPolicyId)) {
+                    $loanPolicyData = $this->getLoanPolicyData($loanPolicyId);
+                }
+
+                // Cache bib numbers by item id to improve login speed for users
+                // who login a second time. For some reason getBibId is very slow.
+                $cacheKey = 'loanBibMap';
+                $loanBibMap = $this->getCachedData($cacheKey);
+                if (!empty($loanBibMap[$itemId])) {
+                    $bib = $loanBibMap[$itemId]['bib'];
+                } else {
+                    $bib = $this->getBibId($trans['item_instance_id']);
+                    $loanBibMap[$itemId] = compact('bib');
+                }
+                $this->putCachedData($cacheKey, $loanBibMap);
+
+                // Set bib number and item information
+                $transactions[$i]['id'] = $bib;
+                $transactions[$i]['location'] = $locationData['name'] ?? '';
+                $transactions[$i]['loan_policy'] = $loanPolicyData['desc'] ?? '';
+                $transactions[$i]['callnumber'] = $callnumber;
+            }
         }
         return $transactions;
     }
@@ -743,6 +779,35 @@ class Folio extends \VuFind\ILS\Driver\Folio
         );
         $data = json_decode($response->getBody());
         return $data;
+    }
+
+    protected function dateComp($key)
+    {
+        return function ($a, $b) use ($key) {
+            if ($a[$key] == $b[$key]) {
+                return $a['id'] < $b['id'] ? -1 : 1;
+            }
+            return $a[$key] < $b[$key] ? -1 : 1;
+        };
+    }
+
+    protected function alphaStringComp($key)
+    {
+        return function($a, $b) use ($key) {
+            return strcasecmp(
+                preg_replace('/[^ \w]+/', '', $a[$key]),
+                preg_replace('/[^ \w]+/', '', $b[$key])
+            );
+        };
+    }
+
+    public function getCoiSort()
+    {
+        if (isset($_GET['sort'])) {
+            return $_GET['sort'];
+        } else {
+            return $this->config['MyAccount']['checkedOutItemsSort'] ?? 'dueDate';
+        }
     }
 }
 

--- a/module/UChicago/src/UChicago/ILS/Driver/Folio.php
+++ b/module/UChicago/src/UChicago/ILS/Driver/Folio.php
@@ -4,7 +4,6 @@ namespace UChicago\ILS\Driver;
 
 class Folio extends \VuFind\ILS\Driver\Folio
 {
-
     /**
      * Helper function to retrieve paged results from FOLIO API
      *

--- a/themes/phoenix/templates/myresearch/checkedout.phtml
+++ b/themes/phoenix/templates/myresearch/checkedout.phtml
@@ -24,9 +24,6 @@ $renewAll = !$this->ilsPaging || !$paginator;
     </div>
   <?php endif; ?>
 
-  <div class="alert alert-warning" role="alert">
-    <p>We are currently working to restore the ability to sort checked out items and the display of some data fields.</p>
-  </div>
   <div class="alert alert-info" role="alert">
     <p>University of Chicago Library materials on standard loan will be renewed automatically up to their online renewal limit, unless recalled.
     <a href="https://www.lib.uchicago.edu/borrow/borrowing/renewing-and-returning-items/">More info...</a></p>
@@ -63,11 +60,11 @@ $renewAll = !$this->ilsPaging || !$paginator;
       <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf"/>
       <div class="toolbar">
         <div class="checkbox">
-          <label>
+          <!--<label>
             <input type="checkbox" name="selectAll" class="checkbox-select-all"/>
-            <?=$this->transEsc('select_page')?>
+            <?//=$this->transEsc('select_page')?>
           </label>
-          <!--<input type="submit" class="btn btn-default" id="renewSelected" name="renewSelected" value="<?=$this->transEscAttr("renew_selected")?>" />-->
+          <input type="submit" class="btn btn-default" id="renewSelected" name="renewSelected" value="<?=$this->transEscAttr("renew_selected")?>" />-->
           <?php if ($renewAll): ?>
             <!--<input type="submit" class="btn btn-default" id="renewAll" name="renewAll" value="<?=$this->transEscAttr('renew_all')?>" />-->
           <?php endif; ?>


### PR DESCRIPTION
Fixes #130.

## Changes in this request
- Adds sort options to the checked out items page in My Account.
- Refactoring of checked out items code to accommodate sorting while maintaining performance enhancements. 
- Hides unused checkbox in template
- Gets rid of the banner alert about implementing sort options.