### PR TITLE
Items not sorting sequentially

### DIFF
--- a/module/UChicago/src/UChicago/ILS/Driver/Folio.php
+++ b/module/UChicago/src/UChicago/ILS/Driver/Folio.php
@@ -125,6 +125,9 @@ class Folio extends \VuFind\ILS\Driver\Folio
             $purchaseHistory = $this->getPurchaseHistoryData($bibId);
         }
 
+        $serialIDs = $this->config['Holdings']['is_serial_stat_codes'] ?? [];
+        $isSerial = count(array_intersect($serialIDs, $instance->statisticalCodeIds)) > 0;
+
         foreach ($this->getPagedResults(
             'holdingsRecords', '/holdings-storage/holdings', $query
         ) as $holding) {
@@ -258,6 +261,10 @@ class Folio extends \VuFind\ILS\Driver\Folio
                     'loan_type_name' => $loanTypeName,
                 ];
             }
+        }
+        usort($items, function($a, $b) { return strnatcasecmp($a['number'], $b['number']); });
+        if ($isSerial) {
+            return array_reverse($items);
         }
         return $items;
     }


### PR DESCRIPTION
Fixes issue #134. [Bugzilla 26359](https://trouble.lib.uchicago.edu/bugzilla/show_bug.cgi?id=26359)

## Changes in this request
- Sorting by copy number / enumeration for items on the full record page.
- Order is reversed for serials (as was the case in our old implementation)

## Test record (compare to production)
https://dldc2.lib.uchicago.edu/vufind/Record/1625207