### PR TITLE
Only show holding copy number at holdings level

### DIFF
--- a/module/UChicago/src/UChicago/ILS/Driver/Folio.php
+++ b/module/UChicago/src/UChicago/ILS/Driver/Folio.php
@@ -172,7 +172,8 @@ class Folio extends \VuFind\ILS\Driver\Folio
                 }
             }
 
-            $UCcopyNumber = $holding->copyNumber ?? '';
+            $holdingCopyNumber = $holding->copyNumber ?? '';
+            $UCcopyNumber = $holdingCopyNumber;
             $holdingData = clone $holding;
             $holdingData->status = (object) ['name' => ''];
             $holdingLocationId = $holding->effectiveLocationId;
@@ -259,6 +260,7 @@ class Folio extends \VuFind\ILS\Driver\Folio
                     'item_statistical_code' => $itemStatCodeIds[0] ?? '',
                     'loan_type_id' => $loanTypeId,
                     'loan_type_name' => $loanTypeName,
+                    'holding_copy_number' => $holdingCopyNumber,
                 ];
             }
         }

--- a/themes/phoenix/templates/RecordTab/holdingsils.phtml
+++ b/themes/phoenix/templates/RecordTab/holdingsils.phtml
@@ -116,8 +116,8 @@
         <?php if ($this->callnumberHandler): ?>
           <a href="<?=$this->url('alphabrowse-home') ?>?source=<?=$this->escapeHtmlAttr($this->callnumberHandler) ?>&amp;from=<?=$this->escapeHtmlAttr($callNo['callnumber']) ?>"><?=$this->escapeHtml($callNo['display'])?>
             <? ### UChicago customization ### ?>
-            <?php if (!empty($holding['items'][0]['uc_copy_number'])): ?>
-                <?=' '. $holding['items'][0]['uc_copy_number']?>
+            <?php if (!empty($holding['items'][0]['holding_copy_number'])): ?>
+                <?=' '. $holding['items'][0]['holding_copy_number']?>
             <?php endif; ?>
             <? ### ./UChicago customization ### ?></a>
         <?php else: ?>


### PR DESCRIPTION
Only the holdings copy number should be appended to the call number in the holdings block, never the item copy number. If no copy number is available, nothing should be appended. [See Bugzilla 26411](https://trouble.lib.uchicago.edu/bugzilla/show_bug.cgi?id=26411)