### PR TITLE
Dates should not be stipped out of call numbers

### DIFF
--- a/themes/phoenix/templates/RecordTab/holdingsils/standard.phtml
+++ b/themes/phoenix/templates/RecordTab/holdingsils/standard.phtml
@@ -60,10 +60,6 @@
             <?php else: ?>
               <?php $c = $callNos['sort'][$numKey]; ?>
             <?php endif; ?>
-            <?php // hAcK, handle bad data ?>
-            <?php if (isset($c)): ?>
-              <?php $c = explode(' ', $c)[0]; ?>
-            <?php endif;?>
             <a href="/vufind/alphabrowse/home?from=<?=$c;?>&source=lcc&consult=true">consult the series record</a>.
           <?php endif; ?>
           <? ### ./UChicago customization ### ?>


### PR DESCRIPTION
Fixes #145 

**Changes in this pull request**
- Removes code that stripped everything after an empty space in a call number.

I believe this hack was legacy code that existed before we had separate sort call numbers and I think it was only left in as an extra guard. I do not believe it is needed.