### PR TITLE
Sanitize titles in callnumber alphabrowse and autosuggester

### DIFF
--- a/module/UChicago/config/module.config.php
+++ b/module/UChicago/config/module.config.php
@@ -94,6 +94,14 @@ return [
                     ],
                 ],
             ],
+            'autocomplete' => [
+                'factories' => [
+                    'UChicago\\Autocomplete\\Solr' => 'VuFind\\Autocomplete\\SolrFactory',
+                ],
+                'aliases' => [
+                    'VuFind\\Autocomplete\\Solr' => 'UChicago\\Autocomplete\\Solr',
+                ],
+            ],
         ],
     ],
 ];

--- a/module/UChicago/src/UChicago/Autocomplete/Solr.php
+++ b/module/UChicago/src/UChicago/Autocomplete/Solr.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace UChicago\Autocomplete;
+
+class Solr extends \VuFind\Autocomplete\Solr
+{
+    /**
+     * Given the values from a Solr field and the user's search query, pick the best
+     * match to display as a recommendation.
+     *
+     * @param array|string $value Field value (or array of field values)
+     * @param string       $query User search query
+     * @param bool         $exact Ignore non-exact matches?
+     *
+     * @return bool|string        String to use as recommendation, or false if
+     * no appropriate value was found.
+     */
+    protected function pickBestMatch($value, $query, $exact)
+    {
+        // By default, assume no match:
+        $bestMatch = false;
+
+        // Different processing for arrays vs. non-arrays:
+        if (is_array($value) && !empty($value)) {
+            // Do any of the values within this multi-valued array match the
+            // query?  Try to find the closest available match.
+            foreach ($value as $next) {
+                if ($this->matchQueryTerms($next, $query)) {
+                    $bestMatch = $next;
+                    break;
+                }
+            }
+
+            // If we didn't find an exact match, use the first value unless
+            // we have the "precise matches only" property set, in which case
+            // we don't want to use any of these values.
+            if (!$bestMatch && !$exact) {
+                $bestMatch = $value[0];
+            }
+        } else {
+            // If we have a single value, we will use it if we're in non-strict
+            // mode OR if we're in strict mode and it actually matches.
+            if (!$exact || $this->matchQueryTerms($value, $query)) {
+                ### UChicago customization ###
+                $bestMatch = htmlspecialchars($value);
+                ### ./UChicago customization ###
+            }
+        }
+        return $bestMatch;
+    }
+}
+

--- a/themes/phoenix/templates/alphabrowse/home.phtml
+++ b/themes/phoenix/templates/alphabrowse/home.phtml
@@ -144,6 +144,9 @@
                 foreach ($item['extras'][$extraName] as $j => $e):
                   $extraDisplayArray = array_unique(array_merge($extraDisplayArray, $e));
                 endforeach;
+                ### UChicago customization ###
+                $extraDisplayArray = array_map('htmlspecialchars', $extraDisplayArray);
+                ### ./UChicago customization ###
                 echo empty($extraDisplayArray) ? '&nbsp;' : implode('<br />', $extraDisplayArray);
               ?>
             </td>


### PR DESCRIPTION
Fixes #149

**Changes in this request**
- Applies `htmlspecialchars` to titles in the callnumber browse and autosuggester to prevent js injection. [See Bugzilla 26346 for more information](https://trouble.lib.uchicago.edu/bugzilla/show_bug.cgi?id=26346).