### PR TITLE
Emailed record comments are lost

### DIFF
--- a/themes/phoenix/templates/Email/record.phtml
+++ b/themes/phoenix/templates/Email/record.phtml
@@ -19,3 +19,7 @@ foreach ($holdings['holdings'] as $location => $holding) {
 ?>
 <?=$this->serverUrl($this->recordLink()->getUrl($this->driver))?>
 <?="\n\n"?>
+------------------------------------------------------------
+<?php if (!empty($this->message)): ?><?=$this->translate("Message From Sender")?>:
+<?=$this->message?>
+<?php endif; ?>


### PR DESCRIPTION
Fixes #157 

Add the message field to the output sent from the email this record form. [See Bugzilla 27021](https://trouble.lib.uchicago.edu/bugzilla/show_bug.cgi?id=27021).