### PR TITLE
remove required by form field from FOLIO driver

### DIFF
--- a/module/UChicago/src/UChicago/ILS/Driver/Folio.php
+++ b/module/UChicago/src/UChicago/ILS/Driver/Folio.php
@@ -673,7 +673,6 @@ class Folio extends \VuFind\ILS\Driver\Folio
                 ];
             } catch (Exception $e) {
                 $this->throwAsIlsException($e, $response->getBody());
-                $this->throwAsIlsException($e, $response->getBody());
             }
         }
         return $result;


### PR DESCRIPTION
This change addresses Bugzilla ticket 26728:
https://trouble.lib.uchicago.edu/bugzilla/show_bug.cgi?id=26728

This involves commenting out two regions of code in the FOLIO driver, and also editing the `Folio.ini` config file in `local/config/vufind`.  Since FOLIO does not seem to require this field, it appears we can get away with just removing it from VuFind.