### PR TITLE
Forward Search Parameters Through Turnstile

### DIFF
--- a/module/UChicago/src/UChicago/Bootstrapper.php
+++ b/module/UChicago/src/UChicago/Bootstrapper.php
@@ -1,5 +1,4 @@
 <?php
-/* This code is only needed until we upgrade to VuFind 11 or later. Look at closed issue #169 and the pull request for branch 169-backport-rate-limiter-and-cloudfare-turnstile to see the full list of files that can be removed after we upgrade. */
 /**
  * VuFind Bootstrapper
  *
@@ -97,11 +96,30 @@ class Bootstrapper extends \VuFind\Bootstrapper
         // hide search or result data from being accessible to Turnstile.
         $response->setStatusCode(307);
         $policyId = $rateLimiterManager->getPolicyIdForEvent($event);
+
+        ### UChicago customization ###
+        ### Pass search queries through Turnstile verification ###
+        // Store full URL with query parameters in session for privacy
+        $redirectKey = 'turnstile_redirect_' . bin2hex(random_bytes(16));
+        $fullUrl = $event->getRequest()->getUri()->toString();
+
+        // Start session if not already started
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        $_SESSION[$redirectKey] = [
+            'url' => $fullUrl,
+            'expires' => time() + 180 // 3-minute expiration
+        ];
+
         // base64_encoding the destination URL is just further obfuscation
         $context = base64_encode(json_encode([
             'policyId' => $policyId,
             'destination' => $event->getRequest()->getUri()->getPath(),
+            'redirectKey' => $redirectKey,
         ]));
+        ### ./UChicago customization ###
         $response->getHeaders()->addHeaderLine(
             'Location',
             $event->getRequest()->getBaseUrl() . '/Turnstile/Challenge?context=' . $context

--- a/module/UChicago/src/UChicago/Controller/TurnstileController.php
+++ b/module/UChicago/src/UChicago/Controller/TurnstileController.php
@@ -101,10 +101,17 @@ class TurnstileController extends AbstractBase implements
      */
     public function verifyAction()
     {
+        ### UChicago customization ###
+        // Extract all POST parameters first to ensure they're available for HMAC verification
+        // Note: $redirectKey must be extracted before HMAC generation since compact($this->hashKeys)
+        // requires all variables listed in $hashKeys to be defined. To not do so creats an HMAC
+        // verification bypass security vulnerability
         $token = $this->params()->fromPost('token');
         $policyId = $this->params()->fromPost('policyId');
         $destination = $this->params()->fromPost('destination');
+        $redirectKey = $this->params()->fromPost('redirectKey');
         $priorHash = $this->params()->fromPost('hash');
+        ### ./UChicago customization ###
 
         $siteKey = $this->config['Turnstile']['siteKey'];
         $newHash = $this->hmac->generate($this->hashKeys, compact($this->hashKeys));
@@ -120,8 +127,6 @@ class TurnstileController extends AbstractBase implements
 
         // Try to retrieve the full URL from session (with query parameters)
         $redirectUrl = $destination; // fallback to path-only destination
-
-        $redirectKey = $this->params()->fromPost('redirectKey');
         if ($redirectKey && isset($_SESSION[$redirectKey])) {
             $sessionData = $_SESSION[$redirectKey];
 

--- a/module/UChicago/src/UChicago/Controller/TurnstileController.php
+++ b/module/UChicago/src/UChicago/Controller/TurnstileController.php
@@ -1,5 +1,4 @@
 <?php
-/* This code is only needed until we upgrade to VuFind 11 or later. Look at closed issue #169 and the pull request for branch 169-backport-rate-limiter-and-cloudfare-turnstile to see the full list of files that can be removed after we upgrade. */
 /**
  * Turnstile Controller
  *
@@ -55,7 +54,9 @@ class TurnstileController extends AbstractBase implements
      *
      * @var array
      */
-    protected $hashKeys = ['siteKey', 'policyId', 'destination'];
+    ### UChicago customization ###
+    protected $hashKeys = ['siteKey', 'policyId', 'destination', 'redirectKey'];
+    ### ./UChicago customization ###
 
     /**
      * Constructor
@@ -114,7 +115,27 @@ class TurnstileController extends AbstractBase implements
         $ipAddress = $this->event->getRequest()->getServer('REMOTE_ADDR');
         $this->turnstile->validateAndCacheResult($token, $policyId, $ipAddress);
 
+        ### UChicago customization ###
+        ### Forward GET parameters for search ###
+
+        // Try to retrieve the full URL from session (with query parameters)
+        $redirectUrl = $destination; // fallback to path-only destination
+
+        $redirectKey = $this->params()->fromPost('redirectKey');
+        if ($redirectKey && isset($_SESSION[$redirectKey])) {
+            $sessionData = $_SESSION[$redirectKey];
+
+            // Check if session data is valid and not expired
+            if (isset($sessionData['url'], $sessionData['expires']) && $sessionData['expires'] > time()) {
+                $redirectUrl = $sessionData['url'];
+            }
+
+            // Clean up the session data
+            unset($_SESSION[$redirectKey]);
+        }
+
         // Either way, return an http redirect to the referrer page.
-        return $this->redirect()->toUrl($destination);
+        return $this->redirect()->toUrl($redirectUrl);
+        ### ./UChicago customization ###
     }
 }

--- a/themes/phoenix/templates/turnstile/challenge.phtml
+++ b/themes/phoenix/templates/turnstile/challenge.phtml
@@ -1,5 +1,4 @@
 <?php
-  /* This code is only needed until we upgrade to VuFind 11 or later. Look at closed issue #169 and the pull request for branch 169-backport-rate-limiter-and-cloudfare-turnstile to see the full list of files that can be removed after we upgrade. */
   $this->headScript()->appendFile($jsLibraryUrl, 'text/javascript', ['defer' => '', 'async' => '']);
   $js = <<<JS
       function turnstileChallengeEnded(token) {
@@ -20,5 +19,8 @@
     <input id="turnstile_token" name="token" type="hidden">
     <input name="policyId" type="hidden" value="<?=$this->escapeHtml($policyId)?>">
     <input name="destination" type="hidden" value="<?=$this->escapeHtml($destination)?>">
+    <?php ### UChicago customization ### ?>
+    <input name="redirectKey" type="hidden" value="<?=$this->escapeHtml($redirectKey ?? '')?>">
+    <?php ### ./UChicago customization ### ?>
     <input name="hash" type="hidden" value="<?=$this->escapeHtml($hash)?>">
 </form>


### PR DESCRIPTION
Fixes #172 

**Summary**:
Fixed issue where users lose their search terms when Turnstile challenges are triggered after searching from the library website. Previously, only the URL path was preserved as the redirect destination, stripping query parameters like `?lookfor=divergent&type=AllFields`.

**Changes**:
- Store full URL with search parameters in session during challenge redirect
- Retrieve complete URL after successful Turnstile verification
- Preserve user privacy by avoiding exposure of search terms to Cloudflare
- Session data expires in 3 minutes and is cleaned up after use

**Testing**:
Code changes are on `dldc2`.
1. Go to a url with search terms, similar to one that would be generated by the library website search widget, e.g. https://dldc2.lib.uchicago.edu/vufind/Search/Results?lookfor=technology&type=JournalTitle&filter%5B%5D=format%3A%22E-Resource%22
2. Verify Turnstile challenge appears for new users
3. Complete challenge and confirm redirect preserves search parameters
4. Verify search results display correctly with original terms
